### PR TITLE
A bunch of fixes

### DIFF
--- a/other/stakes.lua
+++ b/other/stakes.lua
@@ -14,14 +14,16 @@ SMODS.Stake {
     sticker_pos = { x = 0, y = 0 },
     colour = HEX("fcf2c6"),
 	modifiers = function()
-        G.E_MANAGER:add_event(Event({
-            func = function()
-                ease_ante(-1)
-                G.GAME.round_resets.blind_ante = G.GAME.round_resets.blind_ante or G.GAME.round_resets.ante
-                G.GAME.round_resets.blind_ante = G.GAME.round_resets.blind_ante - 1
-                return true
-            end
-        }))
+        if SMODS.stake_from_index(G.GAME.stake) == "stake_bd_offbrand" then
+            G.E_MANAGER:add_event(Event({
+                func = function()
+                    ease_ante(-1)
+                    G.GAME.round_resets.blind_ante = G.GAME.round_resets.blind_ante or G.GAME.round_resets.ante
+                    G.GAME.round_resets.blind_ante = G.GAME.round_resets.blind_ante - 1
+                    return true
+                end
+            }))
+        end
     end,
 }
 
@@ -29,16 +31,6 @@ SMODS.Stake:take_ownership('stake_white', {
     --above_stake = "bd_offbrand",
 	applied_stakes = { "bd_offbrand" },
     prefix_config = { applied_stakes = { mod = false, } },
-	modifiers = function()
-        G.E_MANAGER:add_event(Event({
-            func = function()
-                ease_ante(1)
-                G.GAME.round_resets.blind_ante = G.GAME.round_resets.blind_ante or G.GAME.round_resets.ante
-                G.GAME.round_resets.blind_ante = G.GAME.round_resets.blind_ante + 1
-                return true
-            end
-        }))
-    end,
 },
 true
 )

--- a/other_j/divineintervention.lua
+++ b/other_j/divineintervention.lua
@@ -65,7 +65,10 @@ SMODS.Joker {
                 func = function()
                     if fool then
                         if (G.GAME.last_tarot_planet and G.GAME.last_tarot_planet ~= 'c_fool') then
+                            --G.GAME.consumeable_buffer = G.GAME.consumeable_buffer - 1
+                            draw_card(fool.area, G.play, 1, 'down', false, fool)
                             fool:use_consumeable()
+                            --G.GAME.consumeable_buffer = G.GAME.consumeable_buffer + 1
                         end
                         SMODS.destroy_cards(fool,true,nil)
                     end

--- a/other_j/feli.lua
+++ b/other_j/feli.lua
@@ -671,21 +671,24 @@ SMODS.Joker {
     end,
     
     update = function(self, card, dt)
-        
         if not (card and card.ability and card.ability.timer and card.ability.timer.enabled) then
             return
         end
         
         local timer = card.ability.timer
         
-        if G.TIMERS.REAL - timer.saved_time > timer.maxTime then
-            
-            
-            
+        if G.TIMERS.REAL - timer.saved_time > timer.maxTime and not card.exploded then
+            card.exploded = true
             
             G.E_MANAGER:add_event(Event({
                 func = function()
-                    card:start_dissolve()
+                    local exploded = SMODS.destroy_cards(card, {immediate = true})
+                    if not next(exploded) then
+                        SMODS.calculate_effect{message = "Saved?!", card = card}
+                        timer.saved_time = G.TIMERS.REAL
+                        card.exploded = false
+                        return true
+                    end
                     card_eval_status_text(card, 'extra', nil, nil, nil, {
                         message = "Got You!",
                         colour = G.C.RED

--- a/other_j/feli.lua
+++ b/other_j/feli.lua
@@ -271,32 +271,31 @@ SMODS.Joker {
             loc_vars = function(self, info_queue, card)
                 return {
                     vars = {
-                        card.ability.extra.xmult, card.ability.imm.rank.key,
+                        card.ability.extra.xmult, localize(card.ability.imm.rank.key, "ranks"),
                     }
                 }
             end,
-            load = function(self, card, card_table, other_card)
-                G.E_MANAGER:add_event(Event({
-                    func = function() 
-                        card.ability.imm.rank = pseudorandom_element(SMODS.Ranks, pseudoseed('j_bd_alberto'))
-                        return true 
-                    end
-                }))
-                
-            end,    
             set_ability = function(self, card, initial, info_queue)
-                card.ability.imm.rank = pseudorandom_element(SMODS.Ranks, pseudoseed('j_bd_alberto'))
+                local rank = pseudorandom_element(SMODS.Ranks, pseudoseed('j_bd_alberto'))
+                card.ability.imm.rank = {
+                    id = rank.id,
+                    key = rank.key
+                }
             end,
             calculate = function(self, card, context)
                 if context.individual and context.cardarea == G.hand and not context.end_of_round then
-                    if context.other_card:get_id() == card.ability.imm.rank.nominal then
+                    if context.other_card:get_id() == card.ability.imm.rank.id then
                         return {
                             xmult = card.ability.extra.xmult
                         }
                     end     
                 end
                 if context.end_of_round and context.main_eval and not context.game_over then
-                    card.ability.imm.rank = pseudorandom_element(SMODS.Ranks, pseudoseed('j_bd_alberto'))
+                    local rank = pseudorandom_element(SMODS.Ranks, pseudoseed('j_bd_alberto'))
+                    card.ability.imm.rank = {
+                        id = rank.id,
+                        key = rank.key
+                    }
                     return {
                         message = "Changed!",
                         colour = G.C.FILTER,
@@ -317,7 +316,7 @@ SMODS.Joker {
 				local xmult = 1
 				for _, playing_card in ipairs(G.hand.cards) do
 					if playing_hand or not playing_card.highlighted then
-						if playing_card.facing and not (playing_card.facing == 'back') and not playing_card.debuff and playing_card:get_id() == card.ability.imm.rank.nominal then
+						if playing_card.facing and not (playing_card.facing == 'back') and not playing_card.debuff and playing_card:get_id() == card.ability.imm.rank.id then
 							xmult = xmult * (card.ability.extra.xmult ^ JokerDisplay.calculate_card_triggers(playing_card, nil, true))
 						end
 					end

--- a/sponsors/elchip.lua
+++ b/sponsors/elchip.lua
@@ -60,8 +60,8 @@ BadDirector.Sponsor{
         G.GAME.used_sponsors.spon_bd_elchip_active = true
 
         -- honest to god idk
-        G.GAME.interest_cap = (G.GAME.interest_cap or 5)
-            + 1
+        G.GAME.interest_cap = (G.GAME.interest_cap or 25)
+            + 5
 
         if G.sponsor_images.spon_bd_elchip.next_ad == 0 then
             G.sponsor_images.spon_bd_elchip.next_ad =

--- a/utils/misprinting.lua
+++ b/utils/misprinting.lua
@@ -100,7 +100,8 @@ SMODS.Sound {
     volume = 1.5
 }
 
-function BadDirector.misprint_hand(hand, card, seed, silent)
+function BadDirector.misprint_hand(hand, card, seed, silent, args)
+    args = args or {}
     seed = seed or hand..card.config.center.key
     local params = SMODS.Scoring_Parameter.obj_buffer --Change this to {"chips", "mult"} if we want to actively not give a shit about glop etc
 
@@ -116,21 +117,26 @@ function BadDirector.misprint_hand(hand, card, seed, silent)
     if SMODS.pseudorandom_probability(card, seed, 1, 4) then
         param_action = function (num, param)
             local variance = pseudorandom(seed)
-            local outcome = num * math.floor((variance*1.3 + 0.7) * 100) / 100
+            local min = args[param.."_multiply_min"] or args.multiply_min or 0.7
+            local range = (args[param.."_multiply_max"] or args.multiply_max or 2.0) - min
+            local outcome = num * math.floor((variance*range + min) * 100) / 100
             total_level_result = total_level_result + (outcome / G.GAME.hands[hand]["l_" .. param])
             return outcome
         end
     elseif SMODS.pseudorandom_probability(card, seed, 1, 2) then
         param_action = function (num, param)
             local variance = pseudorandom(seed)
-            local outcome = num + math.floor((variance*29 + 1) * 100) / 100
+            local min = args[param.."_add_min"] or args.add_min or 1
+            local range = (args[param.."_add_min"] or args.add_max or 29) - min
+            local outcome = num + math.floor((variance*range + min) * 100) / 100
             total_level_result = total_level_result + (outcome / G.GAME.hands[hand]["l_" .. param])
             return outcome
         end
     else
         param_action = function (num, param)
-            total_level_result = total_level_result + 0.5
-            return num + (G.GAME.hands[hand]["l_" .. param] and (G.GAME.hands[hand]["l_" .. param] / 2))
+            local amt = args.fixed_result or 0.5
+            total_level_result = total_level_result + amt
+            return num + (G.GAME.hands[hand]["l_" .. param] and (G.GAME.hands[hand]["l_" .. param] * amt))
         end
     end
 
@@ -186,7 +192,7 @@ function BadDirector.misprint_all(card, seed)
     mult = "...", chips = "..."})
     delay(1)
     for hand, v in pairs(G.GAME.hands) do
-        BadDirector.misprint_hand(hand, card, seed, true)
+        BadDirector.misprint_hand(hand, card, seed, true, {add_range = 40})
     end
     G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.2, func = function()
         play_sound('bd_inapmit_fast')

--- a/utils/misprinting.lua
+++ b/utils/misprinting.lua
@@ -100,102 +100,84 @@ SMODS.Sound {
     volume = 1.5
 }
 
-
-function BadDirector.misprint_hand(hand, card, seed)
+function BadDirector.misprint_hand(hand, card, seed, silent)
     seed = seed or hand..card.config.center.key
-    update_hand_text({delay = 0}, {handname = localize(hand, "poker_hands"), level = G.GAME.hands[hand].level, 
-    mult = G.GAME.hands[hand].mult, chips = G.GAME.hands[hand].chips, hand})
-    delay(1)
-    if SMODS.pseudorandom_probability(card, seed, 1, 4) then
-        local range = math.floor((pseudorandom(seed)*1.3 + 0.7) * 100) / 100
-        local range2 = math.floor((pseudorandom(seed)*1.3 + 0.7) * 100) / 100
-        G.GAME.hands[hand].mult = G.GAME.hands[hand].mult * range
-        G.GAME.hands[hand].chips = G.GAME.hands[hand].chips * range2
-        G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.2, func = function()
-            play_sound('bd_inapmit_fast')
-            if card and card.juice_up then card:juice_up(0.8, 0.5) end
-            G.TAROT_INTERRUPT_PULSE = true
-            return true end }))
-        update_hand_text({delay = 0}, {mult = "X"..range, StatusText = true})
-        G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.9, func = function()
-            play_sound('bd_inapmit_fast')
-            if card and card.juice_up then card:juice_up(0.8, 0.5) end
-            return true end }))
-            G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.9, func = function()
-            play_sound('bd_inapmit_fast')
-            if card and card.juice_up then card:juice_up(0.8, 0.5) end
-            return true end }))
+    local params = SMODS.Scoring_Parameter.obj_buffer --Change this to {"chips", "mult"} if we want to actively not give a shit about glop etc
+
+    if not silent then
         update_hand_text({delay = 0}, {handname = localize(hand, "poker_hands"), level = G.GAME.hands[hand].level, 
-            mult = G.GAME.hands[hand].mult, chips = G.GAME.hands[hand].chips, hand})
-        update_hand_text({delay = 0}, {chips = "X"..range2, StatusText = true})
-        G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.9, func = function()
-            play_sound('bd_inapmit_fast')
-            if card and card.juice_up then card:juice_up(0.8, 0.5) end
-            G.TAROT_INTERRUPT_PULSE = nil
-            return true end }))
-        update_hand_text({delay = 0}, {handname = localize(hand, "poker_hands"), level = G.GAME.hands[hand].level, 
-            mult = G.GAME.hands[hand].mult, chips = G.GAME.hands[hand].chips, hand})
-        update_hand_text({sound = 'button', volume = 0.7, pitch = 0.9, delay = 0}, {level=G.GAME.hands[hand].level})
-        delay(1.3)
-    elseif SMODS.pseudorandom_probability(card, seed, 1, 2) then
-        local range = math.floor((pseudorandom(seed)*29 + 1) * 100) / 100
-        local range2 = math.floor((pseudorandom(seed)*29 + 1) * 100) / 100
-        G.GAME.hands[hand].mult = G.GAME.hands[hand].mult + range
-        G.GAME.hands[hand].chips = G.GAME.hands[hand].chips + range2
-        G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.2, func = function()
-            play_sound('bd_inapmit_fast')
-            if card and card.juice_up then card:juice_up(0.8, 0.5) end
-            G.TAROT_INTERRUPT_PULSE = true
-            return true end }))
-        update_hand_text({delay = 0}, {mult = G.GAME.hands[hand].mult, StatusText = true})
-        G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.9, func = function()
-            play_sound('bd_inapmit_fast')
-            if card and card.juice_up then card:juice_up(0.8, 0.5) end
-            return true end }))
-            G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.9, func = function()
-            play_sound('bd_inapmit_fast')
-            if card and card.juice_up then card:juice_up(0.8, 0.5) end
-            return true end }))
-        update_hand_text({delay = 0}, {chips = G.GAME.hands[hand].chips, StatusText = true})
-        G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.9, func = function()
-            play_sound('bd_inapmit_fast')
-            if card and card.juice_up then card:juice_up(0.8, 0.5) end
-            G.TAROT_INTERRUPT_PULSE = nil
-            return true end }))
-        update_hand_text({sound = 'button', volume = 0.7, pitch = 0.9, delay = 0}, {level=G.GAME.hands[hand].level})
-        delay(1.3)
-    else    
-        G.GAME.hands[hand].mult = G.GAME.hands[hand].mult + 0.5
-        G.GAME.hands[hand].chips = G.GAME.hands[hand].chips + 0.5
-        G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.2, func = function()
-            play_sound('bd_inapmit_fast')
-            if card and card.juice_up then card:juice_up(0.8, 0.5) end
-            G.TAROT_INTERRUPT_PULSE = true
-            return true end }))
-        update_hand_text({delay = 0}, {mult = G.GAME.hands[hand].mult, StatusText = true})
-        G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.9, func = function()
-            play_sound('bd_inapmit_fast')
-            if card and card.juice_up then card:juice_up(0.8, 0.5) end
-            return true end }))
-            G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.9, func = function()
-            play_sound('bd_inapmit_fast')
-            if card and card.juice_up then card:juice_up(0.8, 0.5) end
-            return true end }))
-        update_hand_text({delay = 0}, {chips = G.GAME.hands[hand].chips, StatusText = true})
-        G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.9, func = function()
-            play_sound('bd_inapmit_fast')
-            if card and card.juice_up then card:juice_up(0.8, 0.5) end
-            G.TAROT_INTERRUPT_PULSE = nil
-            return true end }))
-        update_hand_text({sound = 'button', volume = 0.7, pitch = 0.9, delay = 0}, {level=G.GAME.hands[hand].level})
-        delay(1.3)
+        mult = G.GAME.hands[hand].mult, chips = G.GAME.hands[hand].chips, hand})
+        delay(1)
     end
-    update_hand_text({ delay = 0 }, {
-        mult = 0,
-        chips = 0,
-        level = "",
-        handname = "",
-    })
+
+    local total_level_result, affected_params = 0,0
+
+    local param_action
+    if SMODS.pseudorandom_probability(card, seed, 1, 4) then
+        param_action = function (num, param)
+            local variance = pseudorandom(seed)
+            local outcome = num * math.floor((variance*1.3 + 0.7) * 100) / 100
+            total_level_result = total_level_result + (outcome / G.GAME.hands[hand]["l_" .. param])
+            return outcome
+        end
+    elseif SMODS.pseudorandom_probability(card, seed, 1, 2) then
+        param_action = function (num, param)
+            local variance = pseudorandom(seed)
+            local outcome = num + math.floor((variance*29 + 1) * 100) / 100
+            total_level_result = total_level_result + (outcome / G.GAME.hands[hand]["l_" .. param])
+            return outcome
+        end
+    else
+        param_action = function (num, param)
+            total_level_result = total_level_result + 0.5
+            return num + (G.GAME.hands[hand]["l_" .. param] and (G.GAME.hands[hand]["l_" .. param] / 2))
+        end
+    end
+
+    for i, parameter in ipairs(params) do
+        if G.GAME.hands[hand][parameter] then
+            affected_params = affected_params + 1
+            G.GAME.hands[hand][parameter] = param_action(G.GAME.hands[hand][parameter], parameter)
+            if not silent then
+                update_hand_text({ delay = 0 }, { [parameter] = G.GAME.hands[hand][parameter], StatusText = true })
+                if i == 1 then
+                    G.E_MANAGER:add_event(Event({
+                        trigger = 'after',
+                        delay = 0.2,
+                        func = function()
+                            play_sound('bd_inapmit_fast')
+                            if card and card.juice_up then card:juice_up(0.8, 0.5) end
+                            G.TAROT_INTERRUPT_PULSE = true
+                            return true
+                        end
+                }))
+                end
+                G.E_MANAGER:add_event(Event({
+                    trigger = 'after',
+                    delay = 0.9,
+                    func = function()
+                        play_sound('bd_inapmit_fast')
+                        if card and card.juice_up then card:juice_up(0.8, 0.5) end
+                        G.TAROT_INTERRUPT_PULSE = true
+                        return true
+                    end
+            }))
+            end
+        end
+    end
+
+    G.GAME.hands[hand].level = G.GAME.hands[hand].level + (total_level_result / affected_params)
+    if not silent then
+        update_hand_text({ sound = 'button', volume = 0.7, pitch = 0.9, delay = 0 }, { level = G.GAME.hands[hand].level })
+        delay(1.3)
+
+        update_hand_text({ delay = 0 }, {
+            mult = 0,
+            chips = 0,
+            level = "",
+            handname = "",
+        })
+    end
 end
 
 function BadDirector.misprint_all(card, seed)
@@ -204,20 +186,7 @@ function BadDirector.misprint_all(card, seed)
     mult = "...", chips = "..."})
     delay(1)
     for hand, v in pairs(G.GAME.hands) do
-        if SMODS.pseudorandom_probability(card, seed, 1, 4) then
-            local range = math.floor((pseudorandom(seed)*1.3 + 0.7) * 100) / 100
-            local range2 = math.floor((pseudorandom(seed)*1.3 + 0.7) * 100) / 100
-            G.GAME.hands[hand].mult = G.GAME.hands[hand].mult * range
-            G.GAME.hands[hand].chips = G.GAME.hands[hand].chips * range2
-        elseif SMODS.pseudorandom_probability(card, seed, 1, 2) then
-            local range = math.floor((pseudorandom(seed)*39 + 1) * 100) / 100
-            local range2 = math.floor((pseudorandom(seed)*39 + 1) * 100) / 100
-            G.GAME.hands[hand].mult = G.GAME.hands[hand].mult + range
-            G.GAME.hands[hand].chips = G.GAME.hands[hand].chips + range2
-        else
-            G.GAME.hands[hand].mult = G.GAME.hands[hand].mult + 0.5
-            G.GAME.hands[hand].chips = G.GAME.hands[hand].chips + 0.5
-        end
+        BadDirector.misprint_hand(hand, card, seed, true)
     end
     G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.2, func = function()
         play_sound('bd_inapmit_fast')

--- a/utils/sponsor.lua
+++ b/utils/sponsor.lua
@@ -1,5 +1,3 @@
-G.P_CENTER_POOLS.bd_Sponsor = G.P_CENTER_POOLS.bd_Sponsor or {}
-
 --- @class BadDirector.Sponsor: SMODS.Voucher
 BadDirector.Sponsor = SMODS.Voucher:extend {
 	unlocked = true,
@@ -22,6 +20,7 @@ BadDirector.Sponsor = SMODS.Voucher:extend {
 	inject = function(self)
 		-- call the parent function to ensure all pools are set
 		-- don't call the voucher one though, we are just using voucher for its redeem code and shader
+		G.P_CENTER_POOLS.bd_Sponsor = G.P_CENTER_POOLS.bd_Sponsor or {}
 		SMODS.Center.inject(self)
 	end,
 }


### PR DESCRIPTION
- Make Offbrand stake just not do its thing if it's not the top stake (todo maybe check for specifically white stake in case someone adds something in between)
- Elchips increases interest payment cap by $1, not principle cap
- Fix crash on switching profiles or languages
- Make that one FNAF reference only say its failure message once
- Divine Intervention doesn't do an off-by-one error trying to use its Fool
- Refactored the code of netCards pla (a lot less copy and pasting the same exact code) and fixed their third option adding 0.5 chips and mult instead of leveling by 0.5
  - Options 1 and 2 now increase hand levels by comparing the resulting stat change to normal level-up amounts; this is a first draft sort of option that can be changed to something else if we want to (e.g. increase by 1 level no matter what)

also ate #7 because git is annoying like that